### PR TITLE
expose API for vendor use

### DIFF
--- a/driven/firestore_api.py
+++ b/driven/firestore_api.py
@@ -229,7 +229,9 @@ def changePrimaryAddressUser(user_document_id, address_id):
 # Packages (internal) API
 #  todo: re-evaluate if user and vendor auth needed here
 
-def createPackageRecord(tracking_num, status, initial_description, vendor, username):
+
+def createPackageRecord(tracking_num, status, initial_description, vendor,
+                        username):
     """ create a record for a package in firestore
 
     """
@@ -258,15 +260,16 @@ def createPackageRecord(tracking_num, status, initial_description, vendor, usern
 
     return package_doc_id
 
+
 def updatePackageStatus(username, package_doc_id, status, status_description):
     try:
         package_ref = db.collection(u'packages').document(package_doc_id)
+        user_doc_id = getDocumentIdOfUser(username)
     except:
         return False
 
     status = status.lower()
     if status == "delivered":
-        user_doc_id = getDocumentIdOfUser(username)
         user_ref = db.collection(u'users').document(user_doc_id)
         user_info = user_ref.get().to_dict()
         undelivered_packages = user_info["undelivered-packages"]
@@ -275,13 +278,24 @@ def updatePackageStatus(username, package_doc_id, status, status_description):
         delivered_packages.append(package_doc_id)
 
         #  update undelivered and delivered packages list in user record
-        user_ref.set({u'undelivered-packages': undelivered_packages, u'delivered-packages':  delivered_packages}, merge=True)
+        user_ref.set(
+            {
+                u'undelivered-packages': undelivered_packages,
+                u'delivered-packages': delivered_packages
+            },
+            merge=True)
 
-    package_ref.set({u'status': status, u'status-description': status_description}, merge=True)
+    package_ref.set(
+        {
+            u'status': status,
+            u'status-description': status_description
+        },
+        merge=True)
     return True
 
 
 # Vendor(internal) API
+
 
 #  get a list of all active addresses and primary address, return None if vendor validation fails
 def getUserAddressesVendor(vendor_id, vendor_token, user_document_id):

--- a/driven/firestore_api.py
+++ b/driven/firestore_api.py
@@ -226,8 +226,8 @@ def changePrimaryAddressUser(user_document_id, address_id):
 
 # Packages API
 
-
 # Vendor(internal) API
+
 
 #  get a list of all active addresses and primary address, return None if vendor validation fails
 def getUserAddressesVendor(vendor_id, vendor_token, user_document_id):
@@ -253,7 +253,7 @@ def getUserAddressesVendor(vendor_id, vendor_token, user_document_id):
 
 #  todo: maybe later
 #  def validateCredVendor(vendor, user_document_id, password):
-    #  pass
+#  pass
 
 
 #  return True if validated, else  False
@@ -277,10 +277,7 @@ def generateTokenVendor(vendor_id, vendor_name):
 
     #  vendor does not exist, so create one
     token = secrets.token_urlsafe(40)
-    vendor_data = {
-        u'name': vendor_name,
-        u'token': token
-    }
+    vendor_data = {u'name': vendor_name, u'token': token}
     db.collection(u'vendors').document(vendor_id).set(vendor_data)
     return token
 

--- a/driven/templates/nav-marco.html
+++ b/driven/templates/nav-marco.html
@@ -17,7 +17,6 @@
           <a class="nav-link" href="pricing">Pricing</a>
         </li>
         <li class="nav-item">
-		<!-- todo:logout endpoint has not been implemented yet, add here after implementation -->
 	  <a class="nav-link" href="/logout">Logout</a>
         </li>
       </ul>

--- a/driven/templates/show-vendor-token.html
+++ b/driven/templates/show-vendor-token.html
@@ -1,0 +1,16 @@
+{%- extends "base.html" %}
+
+{% block content %}
+
+<h1> Vendor ID: {{ vendor_id }} </h1>
+<h1> Vendor name: {{ vendor_name }} </h1>
+<br>
+<h1> Your token is </h1>
+
+<div class="alert alert-info" role="alert">
+	{{ vendor_token }}
+</div>
+
+{%- endblock %}
+
+

--- a/driven/templates/vendor-token.html
+++ b/driven/templates/vendor-token.html
@@ -1,0 +1,21 @@
+{%- extends "base.html" %}
+
+{% block content %}
+
+<form method="post">
+
+	<div class="form-floating mb-3">
+	  <input name="vendor_id" class="form-control" id="floatingInput" placeholder="amazon">
+	  <label for="floatingInput">Vendor ID:</label>
+	</div>
+	<div class="form-floating mb-3">
+	  <input name="vendor_name" class="form-control" id="floatingInput" placeholder="Amazon Inc">
+	  <label for="floatingInput">Vendor Name</label>
+	</div>
+
+	<button type="submit" class="btn btn-success" >Generate token</button>
+
+</form>
+
+{%- endblock %}
+

--- a/driven/views/__init__.py
+++ b/driven/views/__init__.py
@@ -5,6 +5,8 @@ from driven.views import profile
 from driven.views import pricing
 from driven.views import contact
 from driven.views import login
+from driven.views import vendor
+from driven.views import api
 from driven.views import addressvendorsmap
 
 blueprint = Blueprint('views', __name__)
@@ -14,6 +16,8 @@ profile.views(blueprint)
 pricing.views(blueprint)
 contact.views(blueprint)
 login.views(blueprint)
+vendor.views(blueprint)
+api.views(blueprint)
 addressvendorsmap.views(blueprint)
 
 

--- a/driven/views/api.py
+++ b/driven/views/api.py
@@ -45,7 +45,7 @@ def views(bp):
         return resp
 
     @bp.route("/api/createPackageRecord", methods=["POST"])
-    def viewsCreatePackageRecord():
+    def viewCreatePackageRecord():
         data = request.get_json()
         username = data["driven_mail_username"]
         vendor_id = data["driven_mail_vendor_id"]

--- a/driven/views/api.py
+++ b/driven/views/api.py
@@ -53,7 +53,9 @@ def views(bp):
         status = data["status"]
         status_description = data["status_description"]
 
-        package_doc_id = createPackageRecord(tracking_num, status, status_description, vendor_id, username)
+        package_doc_id = createPackageRecord(tracking_num, status,
+                                             status_description, vendor_id,
+                                             username)
 
         message = {
             'status': 200,
@@ -72,7 +74,9 @@ def views(bp):
         status = data["status"]
         status_description = data["status_description"]
 
-        package_record_updated = updatePackageStatus(username, package_doc_id, status, status_description)
+        package_record_updated = updatePackageStatus(username, package_doc_id,
+                                                     status,
+                                                     status_description)
 
         operation_result = "Package record failed to update"
         if package_record_updated:

--- a/driven/views/api.py
+++ b/driven/views/api.py
@@ -1,10 +1,16 @@
 '''
-Sample cURL request:
+Sample cURL requests:
 curl -X POST -H 'Content-Type: application/json' -d '{"driven_mail_username":"anmol", "driven_mail_user_password":"anmol-password","driven_mail_vendor_id":"amazon", "driven_mail_vendor_token":"afdasfafa"}' http://localhost:5000/api/getAddress
+
+curl -X POST -H 'Content-Type: application/json' -d '{"driven_mail_username":"anmol", "driven_mail_vendor_id":"amazon","tracking_num":"randomtrackingnumber", "status":"RECORD CREATED", "status_description":"Package record created at 11:00pm"}' http://localhost:5000/api/createPackageRecord
+
+curl -X POST -H 'Content-Type: application/json' -d '{"driven_mail_username":"anmol", "package_id":"kfArsEseMmcPyDXpJmk2", "status":"IN PROGRESS", "status_description":"Received at local facility"}' http://localhost:5000/api/updatePackageRecord
+
+curl -X POST -H 'Content-Type: application/json' -d '{"driven_mail_username":"anmol", "package_id":"kfArsEseMmcPyDXpJmk2", "status":"DELIVERED", "status_description":"Received at local facility"}' http://localhost:5000/api/updatePackageRecord
 '''
 
 from flask import jsonify, request
-from driven.firestore_api import getUserAddressesVendor, getDocumentIdOfUser, validateCredUser
+from driven.firestore_api import getUserAddressesVendor, getDocumentIdOfUser, validateCredUser, createPackageRecord, updatePackageStatus
 
 
 #  RenderFunctions
@@ -33,6 +39,49 @@ def views(bp):
             'status': 200,
             'message': 'OK',
             'address_id_to_address': address_id_to_address
+        }
+        resp = jsonify(message)
+        resp.status_code = 200
+        return resp
+
+    @bp.route("/api/createPackageRecord", methods=["POST"])
+    def viewsCreatePackageRecord():
+        data = request.get_json()
+        username = data["driven_mail_username"]
+        vendor_id = data["driven_mail_vendor_id"]
+        tracking_num = data["tracking_num"]
+        status = data["status"]
+        status_description = data["status_description"]
+
+        package_doc_id = createPackageRecord(tracking_num, status, status_description, vendor_id, username)
+
+        message = {
+            'status': 200,
+            'message': 'OK',
+            'package_id': package_doc_id
+        }
+        resp = jsonify(message)
+        resp.status_code = 200
+        return resp
+
+    @bp.route("/api/updatePackageRecord", methods=["POST"])
+    def viewUpdatePackageRecord():
+        data = request.get_json()
+        username = data["driven_mail_username"]
+        package_doc_id = data["package_id"]
+        status = data["status"]
+        status_description = data["status_description"]
+
+        package_record_updated = updatePackageStatus(username, package_doc_id, status, status_description)
+
+        operation_result = "Package record failed to update"
+        if package_record_updated:
+            operation_result = "Package record updated"
+
+        message = {
+            'status': 200,
+            'message': 'OK',
+            'operation_result': operation_result
         }
         resp = jsonify(message)
         resp.status_code = 200

--- a/driven/views/api.py
+++ b/driven/views/api.py
@@ -1,0 +1,39 @@
+'''
+Sample cURL request:
+curl -X POST -H 'Content-Type: application/json' -d '{"driven_mail_username":"anmol", "driven_mail_user_password":"anmol-password","driven_mail_vendor_id":"amazon", "driven_mail_vendor_token":"afdasfafa"}' http://localhost:5000/api/getAddress
+'''
+
+from flask import jsonify, request
+from driven.firestore_api import getUserAddressesVendor, getDocumentIdOfUser, validateCredUser
+
+
+#  RenderFunctions
+def views(bp):
+    @bp.route("/api/getAddress", methods=["POST"])
+    def viewGetAddress():
+        data = request.get_json()
+        username = data["driven_mail_username"]
+        user_password = data["driven_mail_user_password"]
+        vendor_id = data["driven_mail_vendor_id"]
+        vendor_token = data["driven_mail_vendor_token"]
+
+        user_doc_id = getDocumentIdOfUser(username)
+        user_valid = validateCredUser(user_doc_id, user_password)
+        if user_valid is False:
+            address_id_to_address = ""
+        else:
+            address_id_to_address = getUserAddressesVendor(
+                vendor_id, vendor_token, user_doc_id)
+
+        #  we get None when the vendor fails to validate with its vendor_id and token
+        if address_id_to_address is None:
+            address_id_to_address = ""
+
+        message = {
+            'status': 200,
+            'message': 'OK',
+            'address_id_to_address': address_id_to_address
+        }
+        resp = jsonify(message)
+        resp.status_code = 200
+        return resp

--- a/driven/views/vendor.py
+++ b/driven/views/vendor.py
@@ -1,0 +1,30 @@
+from flask import render_template, request, session, redirect
+from driven.firestore_api import generateTokenVendor
+
+
+#  RenderFunctions
+def views(bp):
+    @bp.route("/vendorToken", methods=['POST', 'GET'])
+    def viewVendorToken():
+        #  if user is logged in, clear seesion and redirect to index page
+        try:
+            if session["username"]:
+                session.clear()
+                return render_template("vendor-token.html")
+        except:
+            #  here, we know user is not logged in
+            if request.method == "GET":
+                return render_template("vendor-token.html")
+            elif request.method == "POST":
+                vendor_id = request.form.get("vendor_id")
+                vendor_name = request.form.get("vendor_name")
+                token = generateTokenVendor(vendor_id, vendor_name)
+
+                #  when returned token is empty string, the vendor_id is not unique
+                if token == "":
+                    return render_template("vendor-token.html")
+                else:
+                    return render_template("show-vendor-token.html",
+                                           vendor_name=vendor_name,
+                                           vendor_id=vendor_id,
+                                           vendor_token=token)


### PR DESCRIPTION
This PR handles operations relating to vendors like:

- register vendor and generate auth token for them
- validate vendors using their vendor_id and auth token previously given
- get address of user using vendor and user credentials
- create package record for user by vendor
- update status of already created package record
- cache package status in user info for easier access
- manual testing of APIs using cURL

Note: some of these impl might have missing validations for
use and vendors, so check them again.